### PR TITLE
Prevent copying settings from the Prod site

### DIFF
--- a/ARMSlotWebConfig/WebSite.json
+++ b/ARMSlotWebConfig/WebSite.json
@@ -126,7 +126,9 @@
           "dependsOn": [
             "[resourceId('Microsoft.Web/Sites/', variables('webSiteName'))]"
           ],
-          "properties": {}
+          "properties": {
+            "siteConfig": { }
+          }
         }
       ]
     }


### PR DESCRIPTION
Reference: https://stackoverflow.com/questions/50024342/create-azure-web-app-slot-from-arm-template-without-copying-original-web-app-con